### PR TITLE
グラフから直接時間範囲を選択できるドラッグ機能の追加

### DIFF
--- a/src/frontend/src/App.css
+++ b/src/frontend/src/App.css
@@ -146,6 +146,20 @@
   cursor: not-allowed;
 }
 
+.range-selector__buttons {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.range-selector__reset {
+  background: #718096 !important;
+}
+
+.range-selector__reset:hover {
+  background: #4a5568 !important;
+}
+
 .export-button {
   margin-left: auto;
 }

--- a/src/frontend/src/components/RangeSelector.tsx
+++ b/src/frontend/src/components/RangeSelector.tsx
@@ -1,5 +1,5 @@
 import type React from 'react';
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import type { TimeRange } from '../types';
 
 /** バリデーションエラーメッセージ */
@@ -9,8 +9,13 @@ const VALIDATION_ERROR_START_AFTER_END = '開始日時は終了日時より前�
  * 範囲選択コンポーネントの props
  */
 interface RangeSelectorProps {
+  /** 現在適用中の範囲（外部制御、controlled） */
+  range?: TimeRange;
+  /** 後方互換: range が未指定の場合の初期値 */
   initialRange?: TimeRange;
   onRangeChange: (range: TimeRange) => void;
+  /** リセットコールバック（提供時にリセットボタンを表示） */
+  onReset?: () => void;
 }
 
 /**
@@ -24,16 +29,26 @@ function toDateTimeLocal(isoString: string): string {
 /**
  * 範囲選択コンポーネント
  * 解析対象の時間範囲を選択する
- * ※ 親コンポーネントで key を変更することで初期値リセットが可能
+ * controlled モード: range prop で外部から同期
  */
-export const RangeSelector: React.FC<RangeSelectorProps> = ({ initialRange, onRangeChange }) => {
+export const RangeSelector: React.FC<RangeSelectorProps> = ({ range, initialRange, onRangeChange, onReset }) => {
+  const effectiveRange = range ?? initialRange;
   const [start, setStart] = useState(
-    initialRange ? toDateTimeLocal(initialRange.start) : ''
+    effectiveRange ? toDateTimeLocal(effectiveRange.start) : ''
   );
   const [end, setEnd] = useState(
-    initialRange ? toDateTimeLocal(initialRange.end) : ''
+    effectiveRange ? toDateTimeLocal(effectiveRange.end) : ''
   );
   const [validationError, setValidationError] = useState<string | null>(null);
+
+  // 外部からの range 変更を内部 state に同期（controlled モード）
+  useEffect(() => {
+    if (range) {
+      setStart(toDateTimeLocal(range.start));
+      setEnd(toDateTimeLocal(range.end));
+      setValidationError(null);
+    }
+  }, [range]);
 
   /** 適用ボタンクリック時 */
   const handleApply = useCallback(() => {
@@ -70,9 +85,16 @@ export const RangeSelector: React.FC<RangeSelectorProps> = ({ initialRange, onRa
           />
         </label>
       </div>
-      <button onClick={handleApply} disabled={!start || !end}>
-        適用
-      </button>
+      <div className="range-selector__buttons">
+        <button onClick={handleApply} disabled={!start || !end}>
+          適用
+        </button>
+        {onReset && (
+          <button className="range-selector__reset" onClick={onReset} type="button">
+            リセット
+          </button>
+        )}
+      </div>
       {validationError && (
         <p className="range-selector__error" role="alert">{validationError}</p>
       )}

--- a/src/frontend/src/components/__tests__/App.test.tsx
+++ b/src/frontend/src/components/__tests__/App.test.tsx
@@ -19,10 +19,19 @@ vi.mock('react-chartjs-2', () => ({
   },
 }));
 
+// プラグインと hook をモック
+vi.mock('../../plugins/chartDragSelectPlugin', () => ({
+  dragSelectPlugin: { id: 'dragSelect', afterDraw: vi.fn() },
+}));
+
+vi.mock('../../hooks/useChartDragSelect', () => ({
+  useChartDragSelect: vi.fn(),
+  findNearestLabelIndex: vi.fn().mockReturnValue(0),
+}));
+
 // API モジュールをモック
 vi.mock('../../services/api', () => ({
   uploadCsv: vi.fn(),
-  getSessionData: vi.fn(),
   analyzeSlopeForSession: vi.fn().mockResolvedValue({ results: [] }),
 }));
 

--- a/src/frontend/src/components/__tests__/ChartView.test.tsx
+++ b/src/frontend/src/components/__tests__/ChartView.test.tsx
@@ -21,6 +21,16 @@ vi.mock('react-chartjs-2', () => ({
   },
 }));
 
+// プラグインと hook をモック
+vi.mock('../../plugins/chartDragSelectPlugin', () => ({
+  dragSelectPlugin: { id: 'dragSelect', afterDraw: vi.fn() },
+}));
+
+vi.mock('../../hooks/useChartDragSelect', () => ({
+  useChartDragSelect: vi.fn(),
+  findNearestLabelIndex: vi.fn().mockReturnValue(0),
+}));
+
 /** テスト用のカウンターデータを生成 */
 function createMockCounter(name: string, dataCount: number): CounterInfo {
   return {

--- a/src/frontend/src/components/__tests__/RangeSelector.test.tsx
+++ b/src/frontend/src/components/__tests__/RangeSelector.test.tsx
@@ -5,6 +5,7 @@ import type { TimeRange } from '../../types';
 
 describe('RangeSelector', () => {
   const mockOnRangeChange = vi.fn();
+  const mockOnReset = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -123,5 +124,47 @@ describe('RangeSelector', () => {
       start: '2026-02-01T08:00',
       end: '2026-02-01T20:00',
     });
+  });
+
+  it('range prop が変更されると入力フィールドが同期される', () => {
+    const range1: TimeRange = {
+      start: '2026-02-01T10:00:00',
+      end: '2026-02-01T12:00:00',
+    };
+    const range2: TimeRange = {
+      start: '2026-02-01T14:00:00',
+      end: '2026-02-01T16:00:00',
+    };
+
+    const { rerender } = render(<RangeSelector range={range1} onRangeChange={mockOnRangeChange} />);
+
+    const startInput = screen.getByLabelText('開始:') as HTMLInputElement;
+    const endInput = screen.getByLabelText('終了:') as HTMLInputElement;
+    expect(startInput.value).toMatch(/^2026-02-01T10:00/);
+    expect(endInput.value).toMatch(/^2026-02-01T12:00/);
+
+    // range prop を変更して再レンダリング
+    rerender(<RangeSelector range={range2} onRangeChange={mockOnRangeChange} />);
+
+    expect(startInput.value).toMatch(/^2026-02-01T14:00/);
+    expect(endInput.value).toMatch(/^2026-02-01T16:00/);
+  });
+
+  it('onReset が提供されている場合、リセットボタンを表示する', () => {
+    render(<RangeSelector onRangeChange={mockOnRangeChange} onReset={mockOnReset} />);
+    expect(screen.getByRole('button', { name: 'リセット' })).toBeInTheDocument();
+  });
+
+  it('onReset が未提供の場合、リセットボタンを表示しない', () => {
+    render(<RangeSelector onRangeChange={mockOnRangeChange} />);
+    expect(screen.queryByRole('button', { name: 'リセット' })).not.toBeInTheDocument();
+  });
+
+  it('リセットボタンをクリックすると onReset が呼び出される', () => {
+    render(<RangeSelector onRangeChange={mockOnRangeChange} onReset={mockOnReset} />);
+
+    const resetButton = screen.getByRole('button', { name: 'リセット' });
+    fireEvent.click(resetButton);
+    expect(mockOnReset).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/frontend/src/hooks/__tests__/useChartDragSelect.test.ts
+++ b/src/frontend/src/hooks/__tests__/useChartDragSelect.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { snapTo30Min, findNearestLabelIndex } from '../../hooks/useChartDragSelect';
+
+describe('snapTo30Min', () => {
+  it('分が15未満の場合、:00に切り捨てる', () => {
+    expect(snapTo30Min('2026-02-01T10:07:00')).toBe('2026-02-01T10:00:00');
+    expect(snapTo30Min('2026-02-01T10:14:59')).toBe('2026-02-01T10:00:00');
+    expect(snapTo30Min('2026-02-01T10:00:00')).toBe('2026-02-01T10:00:00');
+  });
+
+  it('分が15以上45未満の場合、:30に丸める', () => {
+    expect(snapTo30Min('2026-02-01T10:15:00')).toBe('2026-02-01T10:30:00');
+    expect(snapTo30Min('2026-02-01T10:29:00')).toBe('2026-02-01T10:30:00');
+    expect(snapTo30Min('2026-02-01T10:44:00')).toBe('2026-02-01T10:30:00');
+  });
+
+  it('分が45以上の場合、次の時間の:00に切り上げる', () => {
+    expect(snapTo30Min('2026-02-01T10:45:00')).toBe('2026-02-01T11:00:00');
+    expect(snapTo30Min('2026-02-01T10:59:00')).toBe('2026-02-01T11:00:00');
+  });
+
+  it('23:45以上の場合、翌日の00:00に切り上げる', () => {
+    expect(snapTo30Min('2026-02-01T23:45:00')).toBe('2026-02-02T00:00:00');
+  });
+
+  it('秒を0にリセットする', () => {
+    expect(snapTo30Min('2026-02-01T10:07:35')).toBe('2026-02-01T10:00:00');
+    expect(snapTo30Min('2026-02-01T10:20:45')).toBe('2026-02-01T10:30:00');
+  });
+});
+
+describe('findNearestLabelIndex', () => {
+  const labels = [
+    '2026-02-01T10:00:00',
+    '2026-02-01T10:01:00',
+    '2026-02-01T10:02:00',
+    '2026-02-01T10:03:00',
+    '2026-02-01T10:04:00',
+  ];
+
+  it('完全一致する場合、そのインデックスを返す', () => {
+    expect(findNearestLabelIndex(labels, '2026-02-01T10:02:00')).toBe(2);
+  });
+
+  it('先頭より前のタイムスタンプの場合、0を返す', () => {
+    expect(findNearestLabelIndex(labels, '2026-02-01T09:00:00')).toBe(0);
+  });
+
+  it('末尾より後のタイムスタンプの場合、最後のインデックスを返す', () => {
+    expect(findNearestLabelIndex(labels, '2026-02-01T11:00:00')).toBe(4);
+  });
+
+  it('中間のタイムスタンプの場合、最も近いインデックスを返す', () => {
+    // 10:01:20 は 10:01:00（index 1）に近い
+    expect(findNearestLabelIndex(labels, '2026-02-01T10:01:20')).toBe(1);
+    // 10:01:40 は 10:02:00（index 2）に近い
+    expect(findNearestLabelIndex(labels, '2026-02-01T10:01:40')).toBe(2);
+  });
+
+  it('空の配列の場合、-1を返す', () => {
+    expect(findNearestLabelIndex([], '2026-02-01T10:00:00')).toBe(-1);
+  });
+});

--- a/src/frontend/src/hooks/useChartDragSelect.ts
+++ b/src/frontend/src/hooks/useChartDragSelect.ts
@@ -1,0 +1,234 @@
+import { useEffect, useRef, useCallback } from 'react';
+import type { Chart as ChartJS } from 'chart.js';
+import type { TimeRange } from '../types';
+import type { DragState } from '../plugins/chartDragSelectPlugin';
+
+/** 最小ドラッグ幅（px）。これ未満のドラッグは無視 */
+const MIN_DRAG_DISTANCE_PX = 5;
+/** デフォルトのスナップ間隔（分） */
+const DEFAULT_SNAP_MINUTES = 30;
+/** スナップの境界閾値（分）: この値未満なら切り捨て */
+const SNAP_THRESHOLD_LOW = 15;
+/** スナップの境界閾値（分）: この値以上なら次の時間に切り上げ */
+const SNAP_THRESHOLD_HIGH = 45;
+
+/** hook のオプション */
+interface UseChartDragSelectOptions {
+  chartRef: React.RefObject<ChartJS<'line'> | null>;
+  onDragSelect: (range: TimeRange) => void;
+  snapMinutes?: number;
+  enabled?: boolean;
+}
+
+/**
+ * タイムスタンプを指定分数単位にスナップする（文字列操作ベース、タイムゾーン問題を回避）
+ *
+ * - minutes < 15  → :00 に切り捨て
+ * - minutes < 45  → :30 に丸め
+ * - minutes >= 45 → 次の時間の :00 に切り上げ
+ */
+export function snapTo30Min(isoString: string, _snapMinutes: number = DEFAULT_SNAP_MINUTES): string {
+  // "YYYY-MM-DDTHH:MM:SS" 形式を前提とする
+  const parts = isoString.slice(0, 19);
+  const datePart = parts.slice(0, 10); // YYYY-MM-DD
+  let hours = parseInt(parts.slice(11, 13), 10);
+  const minutes = parseInt(parts.slice(14, 16), 10);
+
+  let snappedMinutes: string;
+  if (minutes < SNAP_THRESHOLD_LOW) {
+    snappedMinutes = '00';
+  } else if (minutes < SNAP_THRESHOLD_HIGH) {
+    snappedMinutes = '30';
+  } else {
+    // 次の時間の :00 に切り上げ
+    hours += 1;
+    snappedMinutes = '00';
+  }
+
+  if (hours >= 24) {
+    // 日をまたぐ場合: Date オブジェクトで正しく日付を繰り上げる
+    const [year, month, day] = datePart.split('-').map(Number);
+    const nextDate = new Date(year, month - 1, day + 1);
+    const y = nextDate.getFullYear();
+    const m = String(nextDate.getMonth() + 1).padStart(2, '0');
+    const d = String(nextDate.getDate()).padStart(2, '0');
+    return `${y}-${m}-${d}T00:00:00`;
+  }
+
+  const hh = String(hours).padStart(2, '0');
+  return `${datePart}T${hh}:${snappedMinutes}:00`;
+}
+
+/**
+ * ラベル配列から指定タイムスタンプに最も近いインデックスを二分探索で取得する
+ */
+export function findNearestLabelIndex(labels: string[], timestamp: string): number {
+  if (labels.length === 0) return -1;
+  if (timestamp <= labels[0]) return 0;
+  if (timestamp >= labels[labels.length - 1]) return labels.length - 1;
+
+  let low = 0;
+  let high = labels.length - 1;
+
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2);
+    if (labels[mid] === timestamp) return mid;
+    if (labels[mid] < timestamp) {
+      low = mid + 1;
+    } else {
+      high = mid - 1;
+    }
+  }
+
+  // low と high の間に挟まれているので、近い方を返す
+  if (high < 0) return 0;
+  if (low >= labels.length) return labels.length - 1;
+
+  const diffLow = Math.abs(new Date(labels[low]).getTime() - new Date(timestamp).getTime());
+  const diffHigh = Math.abs(new Date(labels[high]).getTime() - new Date(timestamp).getTime());
+  return diffLow <= diffHigh ? low : high;
+}
+
+/**
+ * チャートドラッグ選択 hook
+ * Canvas の mousedown/mousemove/mouseup/mouseleave イベントを管理し、
+ * ドラッグ終了時に pixel → timestamp → スナップ変換を行って onDragSelect を呼び出す。
+ * 内部状態は useRef で管理し、mousemove 中の React re-render を発生させない。
+ */
+export function useChartDragSelect({
+  chartRef,
+  onDragSelect,
+  snapMinutes = DEFAULT_SNAP_MINUTES,
+  enabled = true,
+}: UseChartDragSelectOptions): void {
+  const dragStateRef = useRef<DragState>({
+    isDragging: false,
+    startX: 0,
+    currentX: 0,
+  });
+  const rafIdRef = useRef<number | null>(null);
+
+  /** pixel X → ラベルインデックス → タイムスタンプ文字列の変換 */
+  const pixelToTimestamp = useCallback((chart: ChartJS<'line'>, pixelX: number): string | null => {
+    const xScale = chart.scales.x;
+    if (!xScale) return null;
+
+    const rawIndex = xScale.getValueForPixel(pixelX);
+    if (rawIndex == null) return null;
+
+    const index = Math.round(rawIndex);
+    const labels = chart.data.labels as string[] | undefined;
+    if (!labels || index < 0 || index >= labels.length) return null;
+
+    return labels[index];
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const chart = chartRef.current;
+    if (!chart) return;
+
+    const canvas = chart.canvas;
+    if (!canvas) return;
+
+    // ドラッグ状態をチャートインスタンスに紐付ける（プラグインからアクセス用）
+    const chartWithDragState = chart as ChartJS<'line'> & { $dragState?: DragState };
+    chartWithDragState.$dragState = dragStateRef.current;
+
+    const handleMouseDown = (e: MouseEvent) => {
+      const chartArea = chart.chartArea;
+      if (!chartArea) return;
+
+      const rect = canvas.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+
+      // プロットエリア内のみ有効
+      if (x < chartArea.left || x > chartArea.right || y < chartArea.top || y > chartArea.bottom) {
+        return;
+      }
+
+      dragStateRef.current.isDragging = true;
+      dragStateRef.current.startX = x;
+      dragStateRef.current.currentX = x;
+    };
+
+    const handleMouseMove = (e: MouseEvent) => {
+      if (!dragStateRef.current.isDragging) return;
+
+      const rect = canvas.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const chartArea = chart.chartArea;
+
+      // chartArea にクランプ
+      dragStateRef.current.currentX = Math.max(
+        chartArea.left,
+        Math.min(x, chartArea.right)
+      );
+
+      // requestAnimationFrame でスロットル
+      if (rafIdRef.current == null) {
+        rafIdRef.current = requestAnimationFrame(() => {
+          rafIdRef.current = null;
+          chart.draw();
+        });
+      }
+    };
+
+    const handleMouseUp = () => {
+      if (!dragStateRef.current.isDragging) return;
+
+      const { startX, currentX } = dragStateRef.current;
+      dragStateRef.current.isDragging = false;
+
+      // 最小ドラッグ幅チェック
+      if (Math.abs(currentX - startX) < MIN_DRAG_DISTANCE_PX) {
+        chart.draw();
+        return;
+      }
+
+      // 右→左ドラッグ対応: start/end を正規化
+      const leftX = Math.min(startX, currentX);
+      const rightX = Math.max(startX, currentX);
+
+      const startTimestamp = pixelToTimestamp(chart, leftX);
+      const endTimestamp = pixelToTimestamp(chart, rightX);
+
+      if (startTimestamp && endTimestamp) {
+        const snappedStart = snapTo30Min(startTimestamp, snapMinutes);
+        const snappedEnd = snapTo30Min(endTimestamp, snapMinutes);
+
+        // スナップ後も start < end であることを保証
+        if (snappedStart < snappedEnd) {
+          onDragSelect({ start: snappedStart, end: snappedEnd });
+        }
+      }
+
+      chart.draw();
+    };
+
+    const handleMouseLeave = () => {
+      if (dragStateRef.current.isDragging) {
+        dragStateRef.current.isDragging = false;
+        chart.draw();
+      }
+    };
+
+    canvas.addEventListener('mousedown', handleMouseDown);
+    canvas.addEventListener('mousemove', handleMouseMove);
+    canvas.addEventListener('mouseup', handleMouseUp);
+    canvas.addEventListener('mouseleave', handleMouseLeave);
+
+    return () => {
+      canvas.removeEventListener('mousedown', handleMouseDown);
+      canvas.removeEventListener('mousemove', handleMouseMove);
+      canvas.removeEventListener('mouseup', handleMouseUp);
+      canvas.removeEventListener('mouseleave', handleMouseLeave);
+      if (rafIdRef.current != null) {
+        cancelAnimationFrame(rafIdRef.current);
+        rafIdRef.current = null;
+      }
+    };
+  }, [chartRef, onDragSelect, snapMinutes, enabled, pixelToTimestamp]);
+}

--- a/src/frontend/src/plugins/chartDragSelectPlugin.ts
+++ b/src/frontend/src/plugins/chartDragSelectPlugin.ts
@@ -1,0 +1,86 @@
+import type { Plugin, Chart } from 'chart.js';
+
+/** ドラッグ中の状態を保持するための拡張プロパティ */
+export interface DragState {
+  isDragging: boolean;
+  startX: number;
+  currentX: number;
+}
+
+/** プラグインオプション */
+export interface DragSelectPluginOptions {
+  /** 確定済みの選択範囲（ラベルインデックスベース） */
+  selectedStartIndex?: number;
+  /** 確定済みの選択範囲（ラベルインデックスベース） */
+  selectedEndIndex?: number;
+}
+
+/** ドラッグ中オーバーレイの色 */
+const DRAG_OVERLAY_COLOR = 'rgba(54, 162, 235, 0.2)';
+/** 確定後の遮蔽色 */
+const CONFIRMED_MASK_COLOR = 'rgba(0, 0, 0, 0.1)';
+
+/**
+ * Chart.js カスタムプラグイン
+ * - ドラッグ中: 青色半透明の矩形をドラッグ領域に表示
+ * - 確定後: 選択範囲外をグレー半透明で遮蔽し、選択範囲を強調
+ */
+export const dragSelectPlugin: Plugin<'line'> = {
+  id: 'dragSelect',
+
+  afterDraw(chart: Chart<'line'>) {
+    const dragState = (chart as Chart<'line'> & { $dragState?: DragState }).$dragState;
+    const ctx = chart.ctx;
+    const chartArea = chart.chartArea;
+
+    if (!chartArea) return;
+
+    // 1. ドラッグ中のオーバーレイ描画
+    if (dragState?.isDragging) {
+      const left = Math.max(Math.min(dragState.startX, dragState.currentX), chartArea.left);
+      const right = Math.min(Math.max(dragState.startX, dragState.currentX), chartArea.right);
+      const top = chartArea.top;
+      const height = chartArea.bottom - chartArea.top;
+
+      ctx.save();
+      ctx.fillStyle = DRAG_OVERLAY_COLOR;
+      ctx.fillRect(left, top, right - left, height);
+      ctx.restore();
+      return;
+    }
+
+    // 2. 確定済み選択範囲のオーバーレイ描画
+    const pluginOpts = chart.options.plugins?.dragSelect as DragSelectPluginOptions | undefined;
+    if (pluginOpts?.selectedStartIndex != null && pluginOpts?.selectedEndIndex != null) {
+      const xScale = chart.scales.x;
+      if (!xScale) return;
+
+      const startPixel = xScale.getPixelForValue(pluginOpts.selectedStartIndex);
+      const endPixel = xScale.getPixelForValue(pluginOpts.selectedEndIndex);
+      const left = Math.min(startPixel, endPixel);
+      const right = Math.max(startPixel, endPixel);
+      const top = chartArea.top;
+      const height = chartArea.bottom - chartArea.top;
+
+      ctx.save();
+      ctx.fillStyle = CONFIRMED_MASK_COLOR;
+      // 左側の遮蔽
+      if (left > chartArea.left) {
+        ctx.fillRect(chartArea.left, top, left - chartArea.left, height);
+      }
+      // 右側の遮蔽
+      if (right < chartArea.right) {
+        ctx.fillRect(right, top, chartArea.right - right, height);
+      }
+      ctx.restore();
+    }
+  },
+};
+
+// Chart.js のプラグインオプション型を拡張
+declare module 'chart.js' {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  interface PluginOptionsByType<TType extends import('chart.js').ChartType> {
+    dragSelect?: DragSelectPluginOptions;
+  }
+}


### PR DESCRIPTION
Closes #10

## 変更概要
チャートグラフ上でドラッグして時間範囲を選択し、スロープ解析範囲を直感的に指定できる機能を追加。

### 新機能
- グラフ上でのドラッグによる時間範囲選択（30分スナップ）
- 選択範囲のハイライト表示（ドラッグ中 + 確定後）
- ドラッグ ↔ RangeSelector の双方向連動
- 全期間リセットボタン

### 技術アプローチ
- Chart.js カスタムプラグイン + useRef ベースの独自hook（外部依存追加なし）
- fullTimeRange / selectedRange の状態分離
- 範囲変更時はスロープ解析のみ実行（データ再取得なし）

### テスト
- 全61テストパス、ビルド成功